### PR TITLE
bundle update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,8 +56,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.1, >= 2.1.8)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     bindex (0.8.1)
     bootsnap (1.4.5)
@@ -129,9 +129,9 @@ GEM
       mini_portile2 (~> 2.4.0)
     openapi_parser (0.4.1)
     parallel (1.17.0)
-    parser (2.6.3.0)
+    parser (2.6.4.0)
       ast (~> 2.4.0)
-    public_suffix (3.1.1)
+    public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
     rack-test (1.1.0)
@@ -293,7 +293,7 @@ DEPENDENCIES
   webdrivers
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.6.4p104
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
* `parser`
  - CHANGELOG
    - API modifications:
      * Added specs for heredocs with mixed encoding. (#581) (Ilya Bylich)
    
    - Features implemented:
      * ruby27.y: Revert "pipeline operator" (#601) (Koichi ITO)
      * ruby27.y: Fix parsing of mutiple assignment with rescue modifier (#600) (Koichi ITO)
      * ruby27.y: hoisted out f_rest_marg. (#594) (Ilya Bylich)
      * ruby27.y: added pipeline operator. (#592) (Ilya Bylich)
      * ruby27.y: reject safe navigator in LHS of mass-assignment. (#586) (Ilya Bylich)
      * lexer.rl: reject whitespaces in meta and control chars. (#585) (Ilya Bylich)
      * lexer.rl: Reject numparams as symbol literals. (#582) (Ilya Bylich)
      * ruby27.y: Added numbered parameters support. (#565) (Ilya Bylich)
      * lexer.rl: Reject \n and \r in heredoc identifiers starting from 2.7. (#575) (Ilya Bylich)
    
    - Bugs fixed:
      * ruby-parse: print empty string when --emit-json and empty input are given. (#590) (Ilya Bylich)
      * AST_FORMAT: fixed documentation of the string with interpolation. (#589) (Ilya Bylich)
      * builder.rb, processor.rb: Changed format of the procarg0 node. (#587) (Ilya Bylich)
  - Compare URL
    - https://github.com/whitequark/parser/compare/v2.6.3.0...v2.6.4.0
* `publicsuffix`
  - CHANGELOG
    - #### Release 4.0.1
      - CHANGED: Updated definitions.
    - #### Release 4.0.0
      - CHANGED: Minimum Ruby version is 2.3
  - Compare URL
    - https://github.com/weppos/publicsuffix-ruby/compare/v3.1.1...v4.0.1
* `addressable`
  - CHANGELOG
    - added `:compacted` flag to `normalized_query`
    - `heuristic_parse` handles `mailto:` more intuitively
    - refactored validation to use a prepended module
    - dropped explicit support for JRuby 9.0.5.0
    - compatibility w/ public_suffix 4.x
    - performance improvements
  - Compare URL
    - https://github.com/sporkmonger/addressable/compare/addressable-2.6.0...addressable-2.7.0