### PR TITLE
bundle update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ GEM
     websocket-extensions (0.1.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.1.9)
+    zeitwerk (2.1.10)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
* `zeitwerk`
  - CHANGELOG
    - Raises Zeitwerk::NameError with a better error message when a managed file or directory has a name that yields an invalid constant name when inflected. Zeitwerk::NameError is a subclass of NameError.
  - Comapre URL
    - https://github.com/fxn/zeitwerk/compare/v2.1.9...v2.1.10