### PR TITLE
bundle update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    rubyzip (1.2.3)
+    rubyzip (1.2.4)
     sassc (2.2.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)


### PR DESCRIPTION
- `rubyzip`
  - CHANGELOG
    - Do not rewrite zip files opened with open_buffer that have not changed #360
    - Tooling / Documentation
      - Update example_recursive.rb in README #397
      - Hold CI at trusty for now, automatically pick the latest ruby patch version, use rbx-4 and hold jruby at 9.1 #399
  - Compare URL
    - https://github.com/rubyzip/rubyzip/compare/v1.2.3...v1.2.4