### PR TITLE
bundle update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
-    builder (3.2.3)
+    builder (3.2.4)
     byebug (11.0.1)
     capistrano (3.11.2)
       airbrussh (>= 1.0.0)
@@ -192,7 +192,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.0)
+    rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -297,7 +297,7 @@ GEM
     websocket-extensions (0.1.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.2.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
- `rake`
  - CHANGELOG
    - Fixed bug: Reenabled task raises previous exception on second invokation Pull Request  by thorsteneckel
    - Fix an incorrectly resolved arg pattern Pull Request  by mjbellantoni
  - Compare URL
    - https://github.com/ruby/rake/compare/v13.0.0...v13.0.1
- `zeitwerk`
  - CHANGELOG
    - `Zeitwerk::NameError#name` has the name of the missing constant now.
  - Compare URL
    - https://github.com/fxn/zeitwerk/compare/v2.2.1...v2.2.2